### PR TITLE
change ttl time from milliseconds to seconds

### DIFF
--- a/lib/aws/dynamodb/dynamodb-adapter.ts
+++ b/lib/aws/dynamodb/dynamodb-adapter.ts
@@ -16,10 +16,11 @@ export class DynamoDBAdapter {
     }
 
     public async put(item: any) {
+        const currentDateInSeconds = Math.floor((new Date()).getTime() / 1000) + 10;
         const params: DynamoDB.PutItemInput = {
             Item: {
                 ...item,
-                ttl: (new Date()).getTime() + this.ttl,
+                ttl: currentDateInSeconds + this.ttl,
             },
             TableName: this.tableName
         };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@natura-pay/aws-sdk-adapter",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "An Inversion Control of depency to aws-sdk lib",
   "author": "Rodrigo Pinheiro de Almeida <rpinheiroalmeida@gmail.com>",
   "license": "MIT",

--- a/test/integration/dynamodb-adapter.spec.ts
+++ b/test/integration/dynamodb-adapter.spec.ts
@@ -54,7 +54,9 @@ describe('DynamoDB', () => {
             Items: [{
                 Value: '1-Value',
                 messageId: '1',
-                ttl: NOW.getTime() + 100
+                ttl: Math.floor(NOW.getTime() / 1000)
+                    + 10
+                    + 100
             }],
             ScannedCount: 1,
         });
@@ -97,7 +99,9 @@ describe('DynamoDB', () => {
             Items: [{
                 Value: '2-Value',
                 messageId: '1',
-                ttl: NOW.getTime() + 100
+                ttl: Math.floor(NOW.getTime() / 1000)
+                    + 10
+                    + 100
             }],
             ScannedCount: 1,
         });

--- a/test/unit/aws/dynamodb/dynamodb-adapter.spec.ts
+++ b/test/unit/aws/dynamodb/dynamodb-adapter.spec.ts
@@ -43,7 +43,9 @@ describe('DynamodbAdapter', () => {
             expect(db.put).toHaveBeenCalledWith({
                 Item: {
                     key: "value",
-                    ttl: NOW.getTime() + dynamoDBConfig.ttl,
+                    ttl: Math.floor(NOW.getTime() / 1000)
+                        + 10
+                        + dynamoDBConfig.ttl,
                 },
                 TableName: "test"
             });


### PR DESCRIPTION
Change the DynamoDB TTL attribute from milliseconds to seconds.